### PR TITLE
Fix #3 - Add Academy Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ programming. It supports powerful and scalable directed graphs of data routing, 
 logic. It was built to automate the flow of data between systems. While the term 'dataflow' is used in a variety of
 contexts, we use it here to mean the automated and managed flow of information between systems.
 
-| :books: [Documentation](https://fiware-draco.rtfd.io) | :whale: [Docker Hub](https://hub.docker.com/r/ging/fiware-draco) | :dart: [Roadmap](docs/roadmap.md) |
-| ----------------------------------------------------- | ---------------------------------------------------------------- | --------------------------------- |
+| :books: [Documentation](https://fiware-draco.rtfd.io) | :mortar_board: [Academy](https://fiware-academy.readthedocs.io/en/latest/core/draco) | :whale: [Docker Hub](https://hub.docker.com/r/ging/fiware-draco) | :dart: [Roadmap](docs/roadmap.md) |
+| ----------------------------------------------------- |--- | ---------------------------------------------------------------- | --------------------------------- |
 
 ### Terminology
 


### PR DESCRIPTION
The Draco tutorial has been updated and fully integrated into the FIWARE Step-by-Step. I've added the link into the academy and the catalogue, all that remains is to update the link box on the README here. 